### PR TITLE
Fix sync.py import path and error handling

### DIFF
--- a/cron_jobs/sync.py
+++ b/cron_jobs/sync.py
@@ -1,6 +1,15 @@
 import time
 import json
+import os
+import sys
 from apscheduler.schedulers.blocking import BlockingScheduler
+
+# Ensure the project root is on the Python path so that ``services`` can be
+# imported when this script is executed directly.
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
 from services.google_drive import list_files
 
 scheduler = BlockingScheduler()
@@ -11,8 +20,16 @@ def scheduled_sync():
 
 @scheduler.scheduled_job('interval', minutes=30)
 def sync_drive():
-    files = list_files()
-    with open('drive_cache.json', 'w') as f:
+    """Sync Google Drive file list to a local cache file."""
+    try:
+        files = list_files()
+    except FileNotFoundError as exc:
+        # Provide a helpful message when credentials are missing
+        print(f"Unable to sync Drive: {exc}")
+        return
+
+    cache_path = os.path.join(PROJECT_ROOT, 'drive_cache.json')
+    with open(cache_path, 'w') as f:
         json.dump(files, f)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update `cron_jobs/sync.py` to add project root to `sys.path`
- handle missing Google Drive credentials
- write cache file relative to project root

## Testing
- `python -m py_compile cron_jobs/sync.py`
- `python - <<'PY'
import cron_jobs.sync as sync
sync.sync_drive()
PY`

------
https://chatgpt.com/codex/tasks/task_e_6862441af4288332ab0451a0ebfb0da4